### PR TITLE
Remove all references to the crossterm book

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Version master
 
-## Breaking changes
-
-- `sys` module is no longer public
+- Remove all references to the crossterm book
+- `sys` module is no longer public (breaking)
 
 # Version 0.3.1
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ to Windows 7 (not all terminals are tested, see the
 
 `crossterm_cursor` is a sub-crate of the [crossterm](https://crates.io/crates/crossterm) crate. You can use it
 directly, but it's **highly recommended** to use the [crossterm](https://crates.io/crates/crossterm) crate with
-the `cursor` feature enabled (see [feature flags](https://crossterm-rs.github.io/crossterm/docs/feature_flags.html)
-for more info).
+the `cursor` feature enabled.
 
 ## Future
 
@@ -58,15 +57,10 @@ fn main() -> Result<()> {
 }
 ```
 
-It's recommended to use the [Command API](https://crossterm-rs.github.io/crossterm/docs/command.html),
-because this might replace some of the existing API in the future. It is more convenient, faster and
-easier to use.
-
 ## Other Resources
 
 - [API documentation](https://docs.rs/crossterm_cursor/) (with other examples)
 - [Examples repository](https://github.com/crossterm-rs/examples)
-- [The Book](https://crossterm-rs.github.io/crossterm/docs/index.html)
    
 ## Authors
 


### PR DESCRIPTION
To be merged once the new book with warnings will be online.