### PR TITLE
Use SyncReader & InputEvent::CursorPosition for pos_raw()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,5 @@ crossterm_winapi = { version = "0.2.1" }
 
 [dependencies]
 crossterm_utils = { git = "https://github.com/crossterm-rs/crossterm-utils.git", branch = "master", version = "0.3.1" }
+crossterm_input = { git = "https://github.com/crossterm-rs/crossterm-input.git", branch = "zrzka/unix-async-events", version = "0.4.1" }
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ crossterm_winapi = { version = "0.2.1" }
 
 [dependencies]
 crossterm_utils = { git = "https://github.com/crossterm-rs/crossterm-utils.git", branch = "master", version = "0.3.1" }
-crossterm_input = { git = "https://github.com/crossterm-rs/crossterm-input.git", branch = "zrzka/unix-async-events", version = "0.4.1" }
+crossterm_input = { git = "https://github.com/crossterm-rs/crossterm-input.git", branch = "master", version = "0.4.1" }
 lazy_static = "1.4"


### PR DESCRIPTION
## Changes

* Replaces `stdin` reading & parsing with `InputEvent::CursorPosition`
* Fixes https://github.com/crossterm-rs/crossterm/issues/199

## TODO

Once https://github.com/crossterm-rs/crossterm-input/pull/9 is merged to `master`.

- [x] Replace `zrzka/unix-async-events` branch with `master` (`Cargo.toml`)

## Test

Tested with the following code on macOS & Linux:

```rust
use crossterm_cursor::{Result, TerminalCursor};

fn main() -> Result<()> {
    let cursor = TerminalCursor::new();

    cursor.save_position()?;

    cursor.goto(30, 20)?;
    assert_eq!(cursor.pos().unwrap(), (30, 20));

    cursor.restore_position()
}
```